### PR TITLE
Glossary, ACs, desynchronize and sync every tables

### DIFF
--- a/issue-416/README.md
+++ b/issue-416/README.md
@@ -44,9 +44,13 @@ Stating @CamilleLegeron
 
 - AC1 - MH: A user can create a table whose data source is synchronized with an external document
 - AC2 - MH: The synchronization is made when the user requests it.
+  - AC2.1 - MH: The user sees what data have been changed through a diff
+  - AC2.2 - SH: The user also sees what columns are removed or added
 - AC3 - MH: A user can convert an existing data source to a synchronized one
   - AC3.1 - MH: If another table references a data source column, the reference is not broken if the external table has a column of the same id
   - AC3.2 - SH: If the external table references a column of another table, the synchronized data source attempts to lookup locally the same table and the same column using the ids.
+  - AC3.3 - MH: The user sees what data have been changed through a diff
+  - AC3.4 - SH: The user also sees what columns are removed or added
 - AC4 - SH: The user should be able to unlink of a synchronized data source which would become a simple data source;
 
 ## Documents

--- a/issue-416/README.md
+++ b/issue-416/README.md
@@ -53,6 +53,8 @@ Stating @CamilleLegeron
   - AC3.4 - SH: The user also sees what columns are removed or added
 - AC4 - SH: The user should be able to unlink a synchronized table which would become a simple table;
 - AC5 - NTH: A "synchronize every tables" button is offered to the user in the "raw data tables" view;
+- AC6 - SH: Edits to synchronized tables should be forbidden;
+- AC7 - MH: Attachment columns are not retrieved from source tables;
 
 ## Documents
 

--- a/issue-416/README.md
+++ b/issue-416/README.md
@@ -35,23 +35,24 @@ Stating @CamilleLegeron
 <details>
   <summary>Vocabulary</summary>
   <dl>
-    <dt>Synchronized data source</dt><dd>The data source which fetches its data from an external table, and gets its data and columns synchronized with this external table</dd>
-    <dt>External table</dt><dd>Table of another document of the synchronized data source</dd>
+    <dt>Synchronized table</dt><dd>The table which fetches its data from an external table, and gets its data and columns synchronized with this external table</dd>
+    <dt>External table</dt><dd>Table of another document of the synchronized table</dd>
   </dl>
 </details>
 
 ## Acceptance Criteria
 
-- AC1 - MH: A user can create a table whose data source is synchronized with an external document
+- AC1 - MH: A user can create a table whose table is synchronized with an external document
 - AC2 - MH: The synchronization is made when the user requests it.
   - AC2.1 - MH: The user sees what data have been changed through a diff
   - AC2.2 - SH: The user also sees what columns are removed or added
-- AC3 - MH: A user can convert an existing data source to a synchronized one
-  - AC3.1 - MH: If another table references a data source column, the reference is not broken if the external table has a column of the same id
-  - AC3.2 - SH: If the external table references a column of another table, the synchronized data source attempts to lookup locally the same table and the same column using the ids.
+- AC3 - MH: A user can convert an existing table to a synchronized one
+  - AC3.1 - MH: If another table references a column of the table to synchronize, the reference is not broken if the external table has a column of the same id
+  - AC3.2 - SH: If the external table references a column of another table, the synchronized table attempts to lookup locally the same table and the same column using the ids.
   - AC3.3 - MH: The user sees what data have been changed through a diff
   - AC3.4 - SH: The user also sees what columns are removed or added
-- AC4 - SH: The user should be able to unlink of a synchronized data source which would become a simple data source;
+- AC4 - SH: The user should be able to unlink a synchronized table which would become a simple table;
+- AC5 - NTH: A "synchronize every tables" button is offered to the user in the "raw data tables" view;
 
 ## Documents
 

--- a/issue-416/README.md
+++ b/issue-416/README.md
@@ -55,6 +55,7 @@ Stating @CamilleLegeron
 - AC5 - NTH: A "synchronize every tables" button is offered to the user in the "raw data tables" view;
 - AC6 - SH: Edits to synchronized tables should be forbidden;
 - AC7 - MH: Attachment columns are not retrieved from source tables;
+- AC8 - MH: The hidden columns of the external table are synchronized too;
 
 ## Documents
 

--- a/issue-416/README.md
+++ b/issue-416/README.md
@@ -62,6 +62,7 @@ Stating @CamilleLegeron
 - AC6 - SH: Edits to synchronized tables should be forbidden;
 - AC7 - MH: Attachment columns are not retrieved from source tables;
 - AC8 - MH: The hidden columns of the external table are synchronized too;
+- AC9 - MH: The source table may not exist anymore, in such a case the synchronization fails with an explicit message for the user;
 
 ## Documents
 

--- a/issue-416/README.md
+++ b/issue-416/README.md
@@ -21,6 +21,34 @@ Stating @CamilleLegeron
 >
 > Camille
 
+## Glossary
+
+<details>
+  <summary>Acronyms</summary>
+  <dl>
+    <dt>MH</dt><dd>Must Have</dd>
+    <dt>SH</dt><dd>Should Have<dd>
+    <dt>NTH</dt><dd>Nice To Have</dd>
+  </dl>
+</details>
+
+<details>
+  <summary>Vocabulary</summary>
+  <dl>
+    <dt>Synchronized data source</dt><dd>The data source which fetches its data from an external table, and gets its data and columns synchronized with this external table</dd>
+    <dt>External table</dt><dd>Table of another document of the synchronized data source</dd>
+  </dl>
+</details>
+
+## Acceptance Criteria
+
+- AC1 - MH: A user can create a table whose data source is synchronized with an external document
+- AC2 - MH: The synchronization is made when the user requests it.
+- AC3 - MH: A user can convert an existing data source to a synchronized one
+  - AC3.1 - MH: If another table references a data source column, the reference is not broken if the external table has a column of the same id
+  - AC3.2 - SH: If the external table references a column of another table, the synchronized data source attempts to lookup locally the same table and the same column using the ids.
+- AC4 - SH: The user should be able to unlink of a synchronized data source which would become a simple data source;
+
 ## Documents
 
 - [design.md](./design.md)

--- a/issue-416/README.md
+++ b/issue-416/README.md
@@ -37,20 +37,26 @@ Stating @CamilleLegeron
   <dl>
     <dt>Synchronized table / Target table</dt><dd>The table which fetches its data from an external table, and gets its data and columns synchronized with this external table</dd>
     <dt>External table / Source table</dt><dd>Table of another document of the synchronized table (source table should be preferred in the UI)</dd>
+    <dt>Regular table</dt><dd>A table which is not synchronized</dd>
   </dl>
 </details>
 
 ## Acceptance Criteria
 
-- AC1 - MH: A user can create a table whose table is synchronized with an external document
+- AC1 - MH: A user can create a fresh table synchronized with an external document
 - AC2 - MH: The synchronization is made when the user requests it.
-  - AC2.1 - MH: The user sees what data have been changed through a diff
-  - AC2.2 - SH: The user also sees what columns are removed or added
+  - AC2.1 - MH: The columns of the synchronized table are updated/created/deleted so it reflects what exist in the external table
+  - AC2.2 - MH: Idem for the records
+  - AC2.3 - MH: If the external table is not accessible anymore or is deleted, a relevant error is displayed to the user, but the synchronized table continue to exist unless the user decide to delete it
+  - AC2.4 - NTH: If the external table is modified, the user gets notified that changes can be fetched
+  - AC2.5 - NTH: The user sees what data have been changed through a diff
+  - AC2.6 - NTH: The user also sees what columns are removed or added
 - AC3 - MH: A user can convert an existing table to a synchronized one
-  - AC3.1 - MH: If another table references a column of the table to synchronize, the reference is not broken if the external table has a column of the same id
-  - AC3.2 - SH: If the external table references a column of another table, the synchronized table attempts to lookup locally the same table and the same column using the ids.
-  - AC3.3 - MH: The user sees what data have been changed through a diff
-  - AC3.4 - SH: The user also sees what columns are removed or added
+  - AC3.1 - MH: If another regular table references a column of the table to synchronize, the reference is not broken if the external table has a column of the same id
+  - AC3.2 - SH: If the external table references a column of another external table, the two tables are synchronized and the reference continues to work in the synchronized document
+  - AC3.3 - SH: If the external table references a column of another regular table, the reference column is converted to a regular one (type: Ref:... ⇒ Any) in the synchronized table and the display value is stored directly
+  - AC3.4 - NTH: The user sees what data have been changed through a diff
+  - AC3.5 - NTH: The user also sees what columns are removed or added
 - AC4 - SH: The user should be able to unlink a synchronized table which would become a simple table;
 - AC5 - NTH: A "synchronize every tables" button is offered to the user in the "raw data tables" view;
 - AC6 - SH: Edits to synchronized tables should be forbidden;

--- a/issue-416/README.md
+++ b/issue-416/README.md
@@ -35,8 +35,8 @@ Stating @CamilleLegeron
 <details>
   <summary>Vocabulary</summary>
   <dl>
-    <dt>Synchronized table</dt><dd>The table which fetches its data from an external table, and gets its data and columns synchronized with this external table</dd>
-    <dt>External table</dt><dd>Table of another document of the synchronized table</dd>
+    <dt>Synchronized table / Target table</dt><dd>The table which fetches its data from an external table, and gets its data and columns synchronized with this external table</dd>
+    <dt>External table / Source table</dt><dd>Table of another document of the synchronized table (source table should be preferred in the UI)</dd>
   </dl>
 </details>
 

--- a/issue-416/design.md
+++ b/issue-416/design.md
@@ -2,25 +2,27 @@
 
 The user clicks « Add new » → « Add page » and is offered this view:
 
-![select a widget with external data source](https://github.com/gristlabs/grist-core/assets/371705/1835e49e-997a-49b5-8786-ad11c9d1c4da)
+![select a widget with external table](https://github.com/gristlabs/grist-core/assets/371705/1835e49e-997a-49b5-8786-ad11c9d1c4da)
 
 They are offered to select a document from their own instance.
 
 About this idea of entering a table URL, that may be implemented as a NTH enhancement, after the rest of the feature is implemented.
 
-Once the user submits, the data are fetched from the external document and put in a new table and a new data source.
+Once the user submits, the data are fetched from the external document and put in a new table and in a new page.
 
-Then the user can see the table with synchronized data source:
+Then the user can see the synchronized table:
 
 ![left menu with list of tables](https://github.com/gristlabs/grist-core/assets/371705/5d8f3193-4249-44c2-a8f6-45f9881fe0b3)
 
-And the synchronized data source itself:
+And also the synchronized raw table:
 
-![synchronized data source](https://github.com/gristlabs/grist-core/assets/371705/e5efabf6-7de8-40ed-8923-41f2d32a46e6)
+![synchronized raw data tables](https://github.com/gristlabs/grist-core/assets/371705/e5efabf6-7de8-40ed-8923-41f2d32a46e6)
 
-Both data source list and table list would offer another context menu to synchronize the data source:
+Both raw tables list and page list would offer another context menu to synchronize the table:
 
 ![synchronize action in context menu](https://github.com/gristlabs/grist-core/assets/371705/ca662ba2-5be4-4c4a-abf5-763c8c46c675)
+
+In case one synchronized table is rendered in a page, the 🔁 icon would appear.
 
 And I would suggest that also a click to the 🔁 icon would trigger that action.
 
@@ -30,9 +32,9 @@ When they trigger this action, the user is offered a popup to review the changes
 
 # Import into an existing table
 
-Use case: a user used to copy tables from a document to another, and want to synchronize the data sources.
+Use case: a user used to copy tables from a document to another, and wants to synchronize the data (NB: one-way synchronization).
 
-![Contextual menu of data source with *Initiate a data source*](https://github.com/fflorent/grist-issues-proposals/assets/371705/9f0e7dd1-97e2-4093-87c5-a89e9d4092f4)
+![Contextual menu of raw table with *Initiate a synchronization*](https://github.com/fflorent/grist-issues-proposals/assets/371705/9f0e7dd1-97e2-4093-87c5-a89e9d4092f4)
 
 Then the user is offered the same popup to validate the changes:
 
@@ -42,6 +44,14 @@ The user also sees what columns are removed and what columns are added:
 
 **TODO** (not implemented in snapshots comparisons)
 
-# Forget / break the link
+# Desynchronize a document
 
-To be done
+The user would be offer a "Remove synchronization" item in the contextual menu of a synchronized raw data table
+
+![contextual menu of a synchronized table](https://github.com/fflorent/grist-issues-proposals/assets/371705/4b5a14a8-13c7-48d5-9dfd-d2c718db7973)
+
+# Synchronize every tables
+
+The user would be offer the "Synchronize every tables" in the raw data tables:
+
+!["synchronize every tables" button at the bottom of the raw data tables list](https://github.com/fflorent/grist-issues-proposals/assets/371705/4f53abdb-db9a-419d-a663-4d60c665dd86)

--- a/issue-416/design.md
+++ b/issue-416/design.md
@@ -1,12 +1,15 @@
 # Import from scratch
 
-The user clicks « Add new » → « Add page » and is offered this view:
+The user clicks « Add new » → « Import table from document »:
 
-![select a widget with external table](https://github.com/gristlabs/grist-core/assets/371705/1835e49e-997a-49b5-8786-ad11c9d1c4da)
+![Import table from document item](https://github.com/fflorent/grist-issues-proposals/assets/371705/6aa87e16-1f29-4a7b-ac47-71c7ff213aa8)
+
+And then a popin appears with some fields to fill to retrieve the table to import:
+![2023-07-26_14-58](https://github.com/fflorent/grist-issues-proposals/assets/371705/fcad24b8-251f-42a9-a586-645e81b94dfa)
+
+NB: the select box should propose a way to filter the options and the « link the table ...» field is checked by default.
 
 They are offered to select a document from their own instance.
-
-About this idea of entering a table URL, that may be implemented as a NTH enhancement, after the rest of the feature is implemented.
 
 Once the user submits, the data are fetched from the external document and put in a new table and in a new page.
 

--- a/issue-416/design.md
+++ b/issue-416/design.md
@@ -4,11 +4,9 @@ The user clicks « Add new » → « Add page » and is offered this view:
 
 ![select a widget with external data source](https://github.com/gristlabs/grist-core/assets/371705/1835e49e-997a-49b5-8786-ad11c9d1c4da)
 
-(at least with more cosmetic :sweat_smile:)
-
 They are offered to select a document from their own instance.
 
-About this idea of entering a table URL, that should lead to the same instance or to a public document, I am not sure how difficult it would be to implement that, I would suggest to implement it later if we want to.
+About this idea of entering a table URL, that may be implemented as a NTH enhancement, after the rest of the feature is implemented.
 
 Once the user submits, the data are fetched from the external document and put in a new table and a new data source.
 
@@ -32,7 +30,17 @@ When they trigger this action, the user is offered a popup to review the changes
 
 # Import into an existing table
 
-To be done
+Use case: a user used to copy tables from a document to another, and want to synchronize the data sources.
+
+![Contextual menu of data source with *Initiate a data source*](https://github.com/fflorent/grist-issues-proposals/assets/371705/9f0e7dd1-97e2-4093-87c5-a89e9d4092f4)
+
+Then the user is offered the same popup to validate the changes:
+
+![2023-07-20_15-51](https://github.com/gristlabs/grist-core/assets/371705/b2ef24ba-5302-4cde-9613-69a05e2e3e9a)
+
+The user also sees what columns are removed and what columns are added:
+
+**TODO** (not implemented in snapshots comparisons)
 
 # Forget / break the link
 

--- a/issue-416/technical.md
+++ b/issue-416/technical.md
@@ -1,0 +1,40 @@
+# Technical proposal
+
+## API
+
+3 new APIs are introduced:
+ - `POST /api/docs/:docId/tables/:tableId/source` to allow attaching a source to a table
+   - passed data:
+     - in the query, `:docId` and `:tableId` refer to the target (synchronized) document / table;
+     - in the body, 2 properties are passed: `docId` and `tableId`, which are the reference to the source table ;
+   - pre-conditions:
+     - the table should not have any source yet (a target table may have only 1 source table, although a source table may have multiple target tables) ;
+     - the passed data reference existing tables in the same site (or even instance?);
+     - the source table id is not taken in the target document by another table
+   - What it does:
+     - it stores the `docId` and the `tableRef` within the document (`_grist_Source_table`);
+     - it copies the id of the source table to the target one;
+ - `DELETE /api/docs/:docId/tables/:tableId/source` to allow detaching a source to a table
+   - passed data:
+     - in the query, `:docId` and `:tableId` refer to the target (synchronized) document / table;
+   - pre-conditions:
+     - the synchronized table should have a source table;
+   - What it does:
+     - it removes the `docId` and the `tableRef` from the document;
+ - `POST /api/docs/:docId/tables/:tableId/sync` to trigger the synchronization
+   - passed data: none
+   - pre-conditions:
+     - the synchronized table should have a source table;
+     - it ensures that the table id of the source table corresponds to the target table (if it does not, it may break formulas, so the API user should change the id of the target table);
+   - What it does:
+     - it replaces the synchronized table columns with the source table ones:
+       - it fetches the columns from the source table;
+       - it filters out the attachment columns;
+       - for the reference columns:
+         - if the referenced column belongs to another table, it should be a synchronized table (otherwise rejects) and the referenced table gets synchronized beforehand;
+         - displayCol + visibleCol => it maps the column ids of the source document with the ones of the target document
+       - it also transforms the "rules" fields (FIXME: HOW? more details needed)
+     - it replaces the synchronized table data:
+       - it fetches the data from the source table;
+       - it filters out the data from the formulas;
+       - for each reference column (whose values are row ids), it maps the column ids of the source document with the ones of the target document;


### PR DESCRIPTION
Proposals for issue https://github.com/gristlabs/grist-core/issues/416

Introduced:
 - [x] A glossary with the hope to clarify the concepts;
 - [x] The Acceptance Criteria (ACs) classified with `Must Have` (MH) > `Should Have` (SH) > `Nice to Have` (NTH);
 - [x] @paulfitz's [idea](https://github.com/gristlabs/grist-core/issues/416#issuecomment-1650342913) to rather see this as an "import" feature
 - [x] a way to de-synchronize a table (aka break / forget a synchronization);
 - [x] a way to synchronize every tables;

To preview the whole document more conveniently, I suggest to use this option:
![view file option in Github](https://github.com/fflorent/grist-issues-proposals/assets/371705/1abbc5ee-9aa4-4b72-829b-4da56dc7de43)
